### PR TITLE
Fix type inference for client and platform properties.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,8 @@ import { ChatwootAPIConfig } from "./core/ChatwootAPI";
 
 export default class ChatwootClient {
     private chatwootAPI: ChatwootAPIConfig;
+    public readonly client;
+    public readonly platform;
 
     constructor({ config }: { config: ChatwootAPIConfig }) {
         this.chatwootAPI = config;
@@ -128,10 +130,7 @@ export default class ChatwootClient {
         this.users = new Users({ config: config });
         this.webhooks = new Webhooks({ config: config });
     }
-
-    public client = {};
-    public platform = {};
-
+    
     public accountAgentBots: AccountAgentBots;
     public agentBots: AgentBots;
     public agents: Agents;


### PR DESCRIPTION
It looks like the TypeScript compiler is having some trouble inferring the types for ChatwootClient's `client` and `platform` properties when using default value assignments outside of the constructor. The properties are just left as `{}` in the resulting `index.d.ts` file.

Screenshot from the [npm package dist](https://www.npmjs.com/package/@figuro/chatwoot-sdk?activeTab=code)

![image](https://github.com/figurolatam/chatwoot-sdk/assets/4034561/816055a2-f9eb-439a-9f54-52cf21ac6ec0)

Removed the default values to fix the issue and marked them as `readonly` for good measure. 👍