### PR TITLE
Use Api-Access-Token

### DIFF
--- a/src/core/request.ts
+++ b/src/core/request.ts
@@ -176,7 +176,7 @@ const getHeaders = async (
 
     if (isStringWithValue(token)) {
         headers["Authorization"] = `Bearer ${token}`;
-        headers["api_access_token"] = token;
+        headers["Api-Access-Token"] = token;
     }
 
     if (isStringWithValue(username) && isStringWithValue(password)) {


### PR DESCRIPTION
ChatWoot supports both `api_access_token` and `Api-Access-Token` header formats ([reference](https://github.com/chatwoot/chatwoot/blob/f44e47a624a19802cb5de9ec950ac624dbbca5b9/config/initializers/rack_attack.rb#L204)), but many NGINX providers ignore underscores, making authentication impossible.

We had to change this in the n8n node and now in TypeScript-related code 👍


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Change header key from `api_access_token` to `Api-Access-Token` in `src/core/request.ts` to ensure compatibility with NGINX providers.
> 
>   - **Behavior**:
>     - Change header key from `api_access_token` to `Api-Access-Token` in `getHeaders()` in `src/core/request.ts`.
>     - Ensures compatibility with NGINX providers that ignore underscores in header names.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=figurolatam%2Fchatwoot-sdk&utm_source=github&utm_medium=referral)<sup> for 7cc8724839a33ac7ecd86671bb877b66d42f01ed. You can [customize](https://app.ellipsis.dev/figurolatam/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->